### PR TITLE
chore(gitconfig): :wrench: Set VS Code as default core editor for git

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -10,3 +10,5 @@
 	program = /Applications/1Password.app/Contents/MacOS/op-ssh-sign
 [commit]
 	gpgsign = true
+[core]
+	editor = code --wait --reuse-window


### PR DESCRIPTION
- :wrench: Configure `code --wait --reuse-window` as the core editor in `.gitconfig`.

This update sets Visual Studio Code as the default core editor, streamlining the experience for commit message creation and other git text editing tasks.